### PR TITLE
Compare with numeric logic in mind, strcmp -> strnatcmp

### DIFF
--- a/src/Debver/Version.php
+++ b/src/Debver/Version.php
@@ -79,7 +79,7 @@ class Version
             /**
              * String compare values
              */
-            $compare = strcmp($value, $version2[$key]);
+            $compare = strnatcmp($value, $version2[$key]);
             if ($compare < 0) {
                 return -1;
             } elseif ($compare > 0) {

--- a/tests/Debver/VersionTest.php
+++ b/tests/Debver/VersionTest.php
@@ -46,7 +46,17 @@ class VersionTest extends PHPUnit_Framework_TestCase
             }
         }
     }
+    
+    public function testVersionBeyondTenCompare()
+    {
+        $ver1 = '2.7.8.dfsg-2+squeeze8';
+        $ver2 = '2.7.8.dfsg-2+squeeze10';
 
+        $compare = Version::compare($ver1, $ver2);
+        $dpkg    = Version::compareWithDpkg($ver1, $ver2);
+
+        $this->assertEquals($dpkg, $compare);
+    }
 
     public function testGetEpochSet()
     {


### PR DESCRIPTION
PHP has a built in compare function which compare with natural (thus also numeric) logic in mind: "strnatcmp"

I runned the test a couple of times (multiple times cause there is a shulfle method in there), and it seems to fix the issue I described in issue #1.

Can you accept this pull request? I use your composer package (less pollution in the packagist database).

If yes, do you mind to uncheck the abandoned checkbox? I will use this and if I find more problems I will try to fix them!
